### PR TITLE
Feature/handle missing camera

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,9 +38,12 @@ for person_name in os.listdir(data_path):
                     face_encode.append(face_encodings[0])  
                     face_name.append(person_name)  
 
-face_cap = cv2.VideoCapture(0)
-if not face_cap.isOpened():
-    print("❌ Error: Could not access the webcam. Please check if it's connected, or if it's being used by another application.")
+try:
+    face_cap = cv2.VideoCapture(0)
+    if not face_cap.isOpened():
+        raise RuntimeError("❌ Error: Could not access the webcam. Please check if it's connected, or if it's being used by another application.")
+except Exception as e:
+    print(str(e))
     sys.exit()
 detection_time = {}  
 last_alarmed = {}    


### PR DESCRIPTION
This pull request addresses Issue #8 by adding proper error handling during webcam initialization in the face recognition system.

 Changes Made:
Added a try-except block around cv2.VideoCapture(0) to handle cases where the webcam is unavailable or busy.
Displayed a clear error message if the webcam could not be accessed.
Used sys.exit() to terminate the program gracefully when webcam access fails.