### PR TITLE
Fix: Prevent screen freeze by threading the alarm sound

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import sys
 from gui.gui import guiwindow
 import datetime
 import pickle
+import threading
 # --- Pause/Resume global state ---
 is_paused = False
 pause_start_time = None
@@ -27,10 +28,10 @@ for directory in [IMAGE_LOG_DIR, CSV_LOG_DIR]:
 
 # Alarms
 def threat_alarm():
-    playsound("alarms/threat.wav")
+    threading.Thread(target=playsound, args=("alarms/threat.wav",), daemon=True).start()
 
 def safe_alarm():
-    playsound("alarms/safe.wav")
+    threading.Thread(target=playsound, args=("alarms/safe.wav",), daemon=True).start()
 
 
 


### PR DESCRIPTION
✅ Fixes #47 

This PR uses Python's `threading.Thread` to run the `playsound()` function asynchronously when threat/safe alarms are triggered.

🎯 Problem: The screen used to freeze during sound playback.
🔧 Solution: Wrapping `playsound()` in a separate thread using `daemon=True`.

Tested behavior on code level. This change allows uninterrupted camera feed while still playing sound alerts.
